### PR TITLE
Update for Java 17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>io.github.juneau001</groupId>
     <artifactId>webapp-jakartaee10</artifactId>
     <packaging>jar</packaging>
-    <version>1.0.1</version>
+    <version>1.1.0</version>
     <name>Jakarta EE 10 WAR Archetype</name>
     <description>Jakarta EE 10 Maven Archetype</description>
     <url>http://maven.apache.org</url>

--- a/src/main/resources/archetype-resources/pom.xml
+++ b/src/main/resources/archetype-resources/pom.xml
@@ -8,11 +8,7 @@
     <name>${artifactId}-${version}</name>
     
     <properties>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
-        <endorsed.dir>${project.build.directory}/endorsed</endorsed.dir>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <failOnMissingWebXml>false</failOnMissingWebXml>
         <jakartaee>10.0.0</jakartaee>
     </properties>
     
@@ -34,43 +30,12 @@
                 <configuration>
                     <source>11</source>
                     <target>11</target>
-                    <compilerArguments>
-                        <endorseddirs>${endorsed.dir}</endorseddirs>
-                    </compilerArguments>
                 </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>2.3</version>
-                <configuration>
-                    <failOnMissingWebXml>false</failOnMissingWebXml>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-dependency-plugin</artifactId>
-                <version>2.6</version>
-                <executions>
-                    <execution>
-                        <phase>validate</phase>
-                        <goals>
-                            <goal>copy</goal>
-                        </goals>
-                        <configuration>
-                            <outputDirectory>${endorsed.dir}</outputDirectory>
-                            <silent>true</silent>
-                            <artifactItems>
-                                <artifactItem>
-                                    <groupId>jakarta.platform</groupId>
-                                    <artifactId>jakarta.jakartaee-api</artifactId>
-                                    <version>${jakartaee}</version>
-                                    <type>jar</type>
-                                </artifactItem>
-                            </artifactItems>
-                        </configuration>
-                    </execution>
-                </executions>
+                <version>3.3.2</version>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
- WAR plugin 2.3 doesn't run with Java 17. Updating to the latest 3.3.2,  which runs with both Java 11 and Java 17
- The default value of `failOnMissingWebXml` in WAR plugin 3.3.2 is false, so removing the `failOnMissingWebXml` config
- Endorsed directory isn't supported in Java 9+, removing support for it

After these changes are merged and deployed to Maven Central, Netbeans needs to be updated to use the new version of this archetype. Currently, Netbeans will generate a EE 10 project which doesn't compile on Java 17 and requires changing the version of the WAR plugin in pom.xml